### PR TITLE
Support regexp namespace

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -344,7 +344,7 @@ Server.prototype.middleware = function () {
 
         //Remove the namespace
         var original_url = request.url;
-        request.url = request.url.substr(namespace.length);
+        request.url = request.url.replace(namespace_prefix, '/');
         info('request url is %s', request.url);
 
         async.eachSeries(middleware, function (stage, next_stage) {

--- a/test/server.js
+++ b/test/server.js
@@ -61,6 +61,24 @@ describe('Server', function () {
         });
     });
 
+    it('should serve images under a RegExp configured namespace', function (done) {
+        var app = server();
+        var randomString = Math.random().toString(36).substr(2, 5);
+        imgr({ namespace: '/.*?'}).serve(images).using(app);
+        assert.statusCode(app.host + '/' + randomString + '/1.jpg', 200, function () {
+            assert.statusCode(app.host + '/' + randomString + '/nested/folder/1.jpg', 200, function () {
+                assert.statusCode(app.host + '/' + randomString + '/2.png', 200, function () {
+                    assert.statusCode(app.host + '/' + randomString + '/nothere.jpg', 404, function () {
+                        assert.statusCode(app.host + '/' + '/nothere.jpg', 404, function () {
+                            app.server.close();
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
     it('should respond to HEAD requests', function (done) {
         var app = server();
         imgr().serve(images).using(app);


### PR DESCRIPTION
To support dynamic urls in namespace configuration like 
`/api/images/.*? `
to enable request like
`/api/images/RandomString12NotInPath/my_images/200x200/image.jpg`